### PR TITLE
Add ssh_key_ids to supported create attributes

### DIFF
--- a/lib/digitalocean/droplet.rb
+++ b/lib/digitalocean/droplet.rb
@@ -52,7 +52,8 @@ module Digitalocean
     #   :name =>        droplet_name, 
     #   :size_id =>     size_id, 
     #   :image_id =>    image_id,
-    #   :region_id =>   region_id
+    #   :region_id =>   region_id,
+    #   :ssh_key_ids => ssh_key_ids
     # }
     def self.create(attrs)
       response = Digitalocean.request.get "droplets/new", attrs


### PR DESCRIPTION
:ssh_key_ids => ssh_key_ids is supported where ssh_key_ids is an array of integers corresponding to ssh keys.

e.g. :ssh_key_ids => [123, 456, 789]
