### PR TITLE
SshKey.create fixed (didn't actually do anything before)

### DIFF
--- a/lib/digitalocean/ssh_key.rb
+++ b/lib/digitalocean/ssh_key.rb
@@ -14,7 +14,7 @@ module Digitalocean
     end
 
     def self.create(attrs)
-      response = Digitalocean.request.get "ssh_keys/new"
+      response = Digitalocean.request.get "ssh_keys/new", attrs
       RecursiveOpenStruct.new(response.body, :recurse_over_arrays => true)
     end
   end


### PR DESCRIPTION
Looks like attrs argument was forgotten for the get call.
