### PR TITLE
Added rspec-its back

### DIFF
--- a/digitalocean.gemspec
+++ b/digitalocean.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "pry"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec"
+  gem.add_development_dependency "rspec-its"
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,5 +3,6 @@ require 'bundler/setup'
 require 'pry'
 require 'digitalocean'
 require 'securerandom'
+require 'rspec/its'
 
 Dir[File.expand_path(File.join(File.dirname(__FILE__),'support','**','*.rb'))].each {|f| require f}


### PR DESCRIPTION
**What does this PR do?**
It puts back the pulled `its` syntax

**Why is this PR needed?**
In rspec3 the `its` syntax was pulled into its own gem, this patch puts it back into this project
